### PR TITLE
CRAN release v0.0.1test

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@
 ^depends\.Rds$
 ^\.ccache$
 ^clang-.*
+^cran-comments\.md$
+^CRAN-RELEASE$

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
+
 
 # Thumbnails
 ._*
@@ -99,7 +101,9 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
+
 
 # Thumbnails
 ._*
@@ -129,3 +133,4 @@ Temporary Items
 
 # Local History for Visual Studio Code
 .history/
+CRAN-RELEASE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tic.package
 Title: Example Package for 'tic'
-Version: 0.0-0
-Date: 2017-06-17
+Version: 0.0.1
+Date: 2020-08-07
 Authors@R: 
     person(given = "Kirill",
            family = "Müller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,32 @@
+# tic.package 0.0.1 (2020-08-07)
+
+* try circle ci
+* push
+* push
+* push
+* push
+* update circleci
+* deploy
+* deploy
+* deploy
+* add cron job
+* try setting env var id_rsa
+* try renv tic
+* test renv
+* use latest tic
+* test deployment
+* do not deploy
+* clean tic.R
+* pkgdown only on travis
+* remove deployment step
+* add badge
+* upd circle yaml
+* upd appveyor.yml
+* minor
+* upd README
+* use tic master
+* upd appveyor
+* upd appveyor
+* qpdf
+
+

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,17 @@
+tic.package 0.0.1
+
+## Cran Repository Policy
+
+- [x] Reviewed CRP last edited 2020-07-11.
+
+## R CMD check results
+
+- [x] Checked locally, R 4.0.2
+- [ ] Checked on CI system, R 4.0.2
+- [ ] Checked on win-builder, R devel
+
+- [ ] Check the boxes above after successful execution and remove this line. Then run `fledge::release()`.
+
+## Current CRAN check results
+
+Initial release.


### PR DESCRIPTION
tic.package 0.0.1

## Cran Repository Policy

- [x] Reviewed CRP last edited 2020-07-11.

## R CMD check results

- [x] Checked locally, R 4.0.2
- [ ] Checked on CI system, R 4.0.2
- [ ] Checked on win-builder, R devel

- [ ] Check the boxes above after successful execution and remove this line. Then run `fledge::release()`.

## Current CRAN check results

Initial release.
